### PR TITLE
chore(.pre-commit-config): update typos to v1.26.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,6 @@ repos:
         stages: [commit-msg]
         additional_dependencies: ['@commitlint/config-conventional']
   - repo: https://github.com/crate-ci/typos
-    rev: v1.25.0
+    rev: v1.26.8
     hooks:
       - id: typos


### PR DESCRIPTION
- Update the `typos` hook in `.pre-commit-config.yaml` to use version `v1.26.8` of the `typos` repository.