### PR TITLE
chore(.pre-commit-config.yaml): update typos to v1.28.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,6 @@ repos:
         stages: [commit-msg]
         additional_dependencies: ['@commitlint/config-conventional']
   - repo: https://github.com/crate-ci/typos
-    rev: v1.27.0
+    rev: v1.28.3
     hooks:
       - id: typos


### PR DESCRIPTION
- Update the `typos` hook in the `.pre-commit-config.yaml` file to use version `v1.28.3` of the `typos` repository.